### PR TITLE
fix(getSchema): close tmp file handle before callback

### DIFF
--- a/lua/yaml-schema-detect/init.lua
+++ b/lua/yaml-schema-detect/init.lua
@@ -286,6 +286,7 @@ local function getSchema(type, callback)
               local file = io.open(tmpFile, "w")
               if file then
                 file:write(table.concat(job:result(), ""))
+                file:close()
                 return callback("file://" .. tmpFile)
               else
                 return callback("")


### PR DESCRIPTION
File handle wasn’t closed after writing, so yaml_ls could sometimes read the schema before it was fully written and error with “Parse error at offset <n>”. Closing the handle before calling callback eliminates this race between getSchema writing file and yaml_ls reading file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where temporary files were not properly closed after writing schema content, improving file handling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->