### PR TITLE
Added possibility to tweak default keymaps & improved docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   'cwrau/yaml-schema-detect.nvim',
-  config = true,
+  opts = {}, -- use default options
   dependencies = {
     'nvim-lua/plenary.nvim',
   },
@@ -46,10 +46,53 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ## Configuration
 
-Add the following to your Neovim configuration:
+Plugin ships with some sensible defaults which you can tweak in your own way.
 
 ```lua
-require('yaml-schema-detect').setup()
+{
+    disable_keymap = false,
+    keymap = {
+        refresh = "<leader>xr",
+        cleanup = "<leader>xyc",
+        info = "<leader>xyi",
+    },
+}
+```
+
+Using [lazy.nvim](https://github.com/folke/lazy.nvim):
+
+Disable default keybindings entirely:
+
+```lua
+{
+  'cwrau/yaml-schema-detect.nvim',
+  opts = {
+      disable_keymap = true,
+  },
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+  },
+  ft = { "yaml" },
+}
+```
+
+Change and toggle default keybindings:
+
+```lua
+{
+  'cwrau/yaml-schema-detect.nvim',
+  opts = {
+    keymap = {
+        refresh = "<leader>yr",
+        cleanup = "<leader>yc",
+        info = false,
+    },
+  },
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+  },
+  ft = { "yaml" },
+}
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Plugin ships with some sensible defaults which you can tweak in your own way.
 
 ```lua
 {
-    disable_keymap = false,
-    keymap = {
-        refresh = "<leader>xr",
-        cleanup = "<leader>xyc",
-        info = "<leader>xyi",
-    },
+  disable_keymap = false,
+  keymap = {
+    refresh = "<leader>xr",
+    cleanup = "<leader>xyc",
+    info = "<leader>xyi",
+  },
 }
 ```
 
@@ -68,8 +68,10 @@ Disable default keybindings entirely:
 ```lua
 {
   'cwrau/yaml-schema-detect.nvim',
+  ---@module "yaml-schema-detect"
+  ---@type YamlSchemaDetectOptions
   opts = {
-      disable_keymap = true,
+    disable_keymap = true,
   },
   dependencies = {
     'nvim-lua/plenary.nvim',
@@ -83,11 +85,13 @@ Change and toggle default keybindings:
 ```lua
 {
   'cwrau/yaml-schema-detect.nvim',
+  ---@module "yaml-schema-detect"
+  ---@type YamlSchemaDetectOptions
   opts = {
     keymap = {
-        refresh = "<leader>yr",
-        cleanup = "<leader>yc",
-        info = false,
+      refresh = "<leader>yr",
+      cleanup = "<leader>yc",
+      info = false,
     },
   },
   dependencies = {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   'cwrau/yaml-schema-detect.nvim',
+  ---@module "yaml-schema-detect"
+  ---@type YamlSchemaDetectOptions
   opts = {}, -- use default options
   dependencies = {
     'nvim-lua/plenary.nvim',

--- a/lua/yaml-schema-detect/init.lua
+++ b/lua/yaml-schema-detect/init.lua
@@ -445,6 +445,7 @@ function M.setup(opts)
       end
     end,
   })
+  if not opts.disable_keymap then
     if opts.keymap.refresh then
       vim.keymap.set("n", opts.keymap.refresh, M.refreshSchema, { desc = "Refresh YAML schema" })
     end

--- a/lua/yaml-schema-detect/init.lua
+++ b/lua/yaml-schema-detect/init.lua
@@ -421,7 +421,17 @@ local function cleanup()
   M.tmpFiles = {}
 end
 
-function M.setup()
+local defaults = {
+    disable_keymap = false,
+    keymap = {
+        refresh = "<leader>xr",
+        cleanup = "<leader>xyc",
+        info = "<leader>xyi",
+    },
+}
+
+function M.setup(opts)
+  opts = vim.tbl_deep_extend("force", defaults, opts or {})
   vim.api.nvim_create_autocmd("LspAttach", {
     group = vim.api.nvim_create_augroup("yaml-schema-detect-lsp-attach", { clear = true }),
     callback = function(event)
@@ -431,11 +441,19 @@ function M.setup()
       end
     end,
   })
-  vim.keymap.set("n", "<leader>xr", M.refreshSchema, { desc = "Refresh YAML schema" })
-  vim.keymap.set("n", "<leader>xyc", cleanup, { desc = "Clean YAML schema files" })
-  vim.keymap.set("n", "<leader>xyi", function()
-    vim.notify(vim.inspect(M))
-  end, { desc = "Show YAML schema info" })
+  if not opts.disable_keymap then
+      if opts.keymap.refresh then
+          vim.keymap.set("n", opts.keymap.refresh, M.refreshSchema, { desc = "Refresh YAML schema" })
+      end
+      if opts.keymap.cleanup then
+          vim.keymap.set("n", "<leader>xyc", cleanup, { desc = "Clean YAML schema files" })
+      end
+      if opts.keymap.info then
+          vim.keymap.set("n", "<leader>xyi", function()
+              vim.notify(vim.inspect(M))
+          end, { desc = "Show YAML schema info" })
+      end
+  end
   vim.api.nvim_create_autocmd("VimLeavePre", {
     desc = "yaml: auto-k8s-schema-detect: cleanup temporary file",
     callback = cleanup,

--- a/lua/yaml-schema-detect/init.lua
+++ b/lua/yaml-schema-detect/init.lua
@@ -421,15 +421,19 @@ local function cleanup()
   M.tmpFiles = {}
 end
 
+---@class YamlSchemaDetectOptions
+---@field disable_keymap? boolean
+---@field keymap? { refresh?: string, cleanup?: string, info?: string }
 local defaults = {
-    disable_keymap = false,
-    keymap = {
-        refresh = "<leader>xr",
-        cleanup = "<leader>xyc",
-        info = "<leader>xyi",
-    },
+  disable_keymap = false,
+  keymap = {
+    refresh = "<leader>xr",
+    cleanup = "<leader>xyc",
+    info = "<leader>xyi",
+  },
 }
 
+---@param opts YamlSchemaDetectOptions?
 function M.setup(opts)
   opts = vim.tbl_deep_extend("force", defaults, opts or {})
   vim.api.nvim_create_autocmd("LspAttach", {
@@ -441,18 +445,17 @@ function M.setup(opts)
       end
     end,
   })
-  if not opts.disable_keymap then
-      if opts.keymap.refresh then
-          vim.keymap.set("n", opts.keymap.refresh, M.refreshSchema, { desc = "Refresh YAML schema" })
-      end
-      if opts.keymap.cleanup then
-          vim.keymap.set("n", opts.keymap.cleanup, cleanup, { desc = "Clean YAML schema files" })
-      end
-      if opts.keymap.info then
-          vim.keymap.set("n", opts.keymap.info, function()
-              vim.notify(vim.inspect(M))
-          end, { desc = "Show YAML schema info" })
-      end
+    if opts.keymap.refresh then
+      vim.keymap.set("n", opts.keymap.refresh, M.refreshSchema, { desc = "Refresh YAML schema" })
+    end
+    if opts.keymap.cleanup then
+      vim.keymap.set("n", opts.keymap.cleanup, cleanup, { desc = "Clean YAML schema files" })
+    end
+    if opts.keymap.info then
+      vim.keymap.set("n", opts.keymap.info, function()
+        vim.notify(vim.inspect(M))
+      end, { desc = "Show YAML schema info" })
+    end
   end
   vim.api.nvim_create_autocmd("VimLeavePre", {
     desc = "yaml: auto-k8s-schema-detect: cleanup temporary file",

--- a/lua/yaml-schema-detect/init.lua
+++ b/lua/yaml-schema-detect/init.lua
@@ -446,10 +446,10 @@ function M.setup(opts)
           vim.keymap.set("n", opts.keymap.refresh, M.refreshSchema, { desc = "Refresh YAML schema" })
       end
       if opts.keymap.cleanup then
-          vim.keymap.set("n", "<leader>xyc", cleanup, { desc = "Clean YAML schema files" })
+          vim.keymap.set("n", opts.keymap.cleanup, cleanup, { desc = "Clean YAML schema files" })
       end
       if opts.keymap.info then
-          vim.keymap.set("n", "<leader>xyi", function()
+          vim.keymap.set("n", opts.keymap.info, function()
               vim.notify(vim.inspect(M))
           end, { desc = "Show YAML schema info" })
       end

--- a/lua/yaml-schema-detect/init.lua
+++ b/lua/yaml-schema-detect/init.lua
@@ -423,7 +423,7 @@ end
 
 ---@class YamlSchemaDetectOptions
 ---@field disable_keymap? boolean
----@field keymap? { refresh?: string, cleanup?: string, info?: string }
+---@field keymap? { refresh?: string|false, cleanup?: string|false, info?: string|false }
 local defaults = {
   disable_keymap = false,
   keymap = {


### PR DESCRIPTION
Hi there!

I ran into a problem with default keymaps: I already have `<leader>x` bound to `<CMD>Trouble diagnostics toggle<cr>`, which I use much more frequently than this plugin's commands. So after installing yaml-schema-detect I noticed ~0.5s delay before executing `<leader>x` because Neovim was waiting for the next key press due to default binds on `<leader>xr`, `<leader>xyc` and `<leader>xyi`.

Currently, changing default behavior is pretty inconvenient because of lazy loading (`vim.keymap.set` executes only after opening some `.yaml` buffer). Therefore the workaround is to run `vim.keymap.del` via autocmd on `LspAttach` event and check for `client.name`, etc. It's not very flexible or user-friendly.

So I made a small change to `M.setup()` to add support for `opts`, allowing users to configure keymaps. Now you can disable and change bindings for specific functions via Lazy's `opts` table.

Also you might consider calling `opts` instead of `config` if you simply want to run `M.setup()` ([Lazy's docs#Best practices](https://lazy.folke.io/developers#best-practices)). And [this](https://github.com/cwrau/yaml-schema-detect.nvim/blob/main/README.md?plain=1#L52) is unnecessary because Lazy handles it automatically.

### Example

Disable default binds entirely:

```lua
{
  'cwrau/yaml-schema-detect.nvim',
  opts = {
      disable_keymap = true,
  },
  dependencies = {
    'nvim-lua/plenary.nvim',
  },
  ft = { "yaml" },
}
```

Override defaults:
```lua
{
  'cwrau/yaml-schema-detect.nvim',
  opts = {
    keymap = {
        refresh = "<leader>yr",
        cleanup = "<leader>yc",
        info = "<leader>yi",
    },
  },
  dependencies = {
    'nvim-lua/plenary.nvim',
  },
  ft = { "yaml" },
}
```

Disable some binds:
```lua
{
  'cwrau/yaml-schema-detect.nvim',
  opts = {
    keymap = {
        refresh = "<leader>yr",
        cleanup = false,
        info = false,
    },
  },
  dependencies = {
    'nvim-lua/plenary.nvim',
  },
  ft = { "yaml" },
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to customize or disable keybindings for plugin commands.
  * Users can now disable all default keybindings or override individual key mappings through configuration.

* **Documentation**
  * Expanded and clarified README with detailed configuration instructions and usage examples.
  * Added examples for customizing and disabling keybindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->